### PR TITLE
Change Measurement.timestamp to i64

### DIFF
--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -20,7 +20,7 @@ pub struct Measurement<'a> {
     pub key: &'a str,
 
     /// Timestamp.
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<i64>,
 
     /// Map of fields.
     pub fields: BTreeMap<&'a str, Value<'a>>,
@@ -78,7 +78,7 @@ impl<'a> Measurement<'a> {
         self.tags.insert(tag, value);
     }
 
-    /// Sets the timestamp of the measurement.
+    /// Sets the timestamp of the measurement. It should be unix timestamp in nanosecond
     ///
     /// # Examples
     ///
@@ -87,9 +87,9 @@ impl<'a> Measurement<'a> {
     ///
     /// let mut measurement = Measurement::new("key");
     ///
-    /// measurement.set_timestamp(1440924047129)
+    /// measurement.set_timestamp(1434055562000000000)
     /// ```
-    pub fn set_timestamp(&mut self, timestamp: i32) {
+    pub fn set_timestamp(&mut self, timestamp: i64) {
         self.timestamp = Some(timestamp);
     }
 }

--- a/src/serializer/line.rs
+++ b/src/serializer/line.rs
@@ -147,6 +147,18 @@ mod tests {
 
         assert_eq!("key,one\\ \\,two=three\\,\\ four,tag=value b=f,f=10,i=10i,one\\,\\ two=\"three\",s=\"string\" 10", serializer.serialize(&measurement));
     }
+
+    #[test]
+    fn test_line_serializer_long_timestamp() {
+        let serializer = LineSerializer::new();
+        let mut measurement = Measurement::new("key");
+
+        measurement.add_field("s", Value::String("string"));
+
+        measurement.set_timestamp(1434055562000000000);
+
+        assert_eq!("key s=\"string\" 1434055562000000000", serializer.serialize(&measurement));
+    }
 }
 
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -37,10 +37,10 @@ fn test_write_measurement() {
     measurement.add_tag("tag", "value");
     measurement.add_tag("tag, with comma", "three, four");
 
-    measurement.set_timestamp(110);
+    measurement.set_timestamp(1434055562000000000);
 
     assert!(client.write_one(measurement, None).is_ok());
 
-    let fixture = "{\"results\":[{\"series\":[{\"name\":\"sut\",\"columns\":[\"time\",\"boolean\",\"float\",\"integer\",\"string\",\"tag\",\"tag, with comma\",\"with, comma\"],\"values\":[[\"1970-01-01T00:00:00.00000011Z\",false,10,10,\"string\",\"value\",\"three, four\",\"comma, with\"]]}]}]}";
+    let fixture = "{\"results\":[{\"series\":[{\"name\":\"sut\",\"columns\":[\"time\",\"boolean\",\"float\",\"integer\",\"string\",\"tag\",\"tag, with comma\",\"with, comma\"],\"values\":[[\"2015-06-11T20:46:02Z\",false,10,10,\"string\",\"value\",\"three, four\",\"comma, with\"]]}]}]}";
     assert_eq!(fixture, client.query("select * from \"sut\"".to_string(), None).unwrap());
 }


### PR DESCRIPTION
Related to https://github.com/gobwas/influent.rs/issues/3

Example:

``` rust
measurement.set_timestamp(1434055562000000000)
```
