### PR TITLE
Port to hyper 0.10.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ default = ["http"]
 http = ["hyper"]
 
 [dependencies]
-hyper = { version = "0.6.8", optional = true }
+hyper = { version = "^0.10.0", optional = true }
 log = "0.3.1"

--- a/src/hurl/hyper.rs
+++ b/src/hurl/hyper.rs
@@ -58,14 +58,7 @@ impl Hurl for HyperHurl {
         match req.query {
             Some(ref query) => {
                 // if any existing pairs
-                let existing: Vec<(String, String)> = match url.query_pairs() {
-                    Some(ref existing) => {
-                        existing.clone()
-                    }
-                    _ => {
-                        Vec::new()
-                    }
-                };
+                let existing: Vec<(String, String)> = url.query_pairs().map(|(a,b)| (a.to_string(), b.to_string())).collect();
 
                 // final pairs
                 let mut pairs: Vec<(&str, &str)> = Vec::new();
@@ -81,7 +74,9 @@ impl Hurl for HyperHurl {
                 }
 
                 // set new pairs
-                url.set_query_from_pairs(pairs.into_iter());
+                url.query_pairs_mut().clear().extend_pairs(
+                    pairs.iter().map(|&(k, v)| { (&k[..], &v[..]) })
+                );
             }
             _ => {}
         };


### PR DESCRIPTION
I am using this lib on my RaspberryPi to save sensor data. While building I ran into https://github.com/sfackler/rust-openssl/issues/314 which is fixed in Hyper 0.8. While I was on it, I ported it to latest hyper upstream.

Tested: Works for me to save one measurement every second through HTTP.