### PR TITLE
Add HTTP consumer using reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ license = "MIT"
 
 [dependencies]
 hyper = { version = "0.12" }
-tokio = "0.1"
-tokio-executor = "0.1"
+reqwest = "0.9"
 http = "0.1"
 url = "1.7"
 futures = "0.1"

--- a/src/hurl/mod.rs
+++ b/src/hurl/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use futures::Future;
 
 pub mod hyper;
+pub mod reqwest;
 
 pub trait Hurl {
     fn request(&self, Request) -> HurlResult;

--- a/src/hurl/reqwest.rs
+++ b/src/hurl/reqwest.rs
@@ -1,0 +1,131 @@
+use reqwest::Client;
+use reqwest::async::Client as ClientAsync;
+use reqwest::Method as ReqwestMethod;
+use url::Url;
+use futures::future::{err as ferr, ok as fok};
+use futures::{Future, Stream};
+
+use super::{Request, Response, Method, HurlResult};
+
+use super::Hurl;
+
+macro_rules! craft_request {
+    ($client:ident, $req:ident) => {{
+        // map request method to the reqwest's
+        let method = match $req.method {
+            Method::POST => ReqwestMethod::POST,
+            Method::GET  => ReqwestMethod::GET,
+        };
+
+        let mut url = match Url::parse($req.url) {
+            Ok(u) => { u }
+            Err(e) => {
+                return Box::new(ferr(format!("could not parse url: {:?}", e)));
+            }
+        };
+
+        // if request has query
+        if let Some(ref query) = $req.query {
+            // if any existing pairs
+            let existing: Vec<(String, String)> = url.query_pairs().map(|(a,b)| (a.to_string(), b.to_string())).collect();
+
+            // final pairs
+            let mut pairs: Vec<(&str, &str)> = Vec::new();
+
+            // add first existing
+            for pair in &existing {
+                pairs.push((&pair.0, &pair.1));
+            }
+
+            // add given query to the pairs
+            for (key, val) in query.iter() {
+                pairs.push((key, val));
+            }
+
+            // set new pairs
+            url.query_pairs_mut().clear().extend_pairs(
+                pairs.iter().map(|&(k, v)| { (&k[..], &v[..]) })
+            );
+        }
+
+        // create query
+        let query = $client.request(method, url.as_str());
+
+        // if request need to be authorized
+        let query = if let Some(auth) = $req.auth {
+            query.basic_auth(auth.username, Some(auth.password))
+        } else {
+            query
+        };
+
+        let query = if let Some(body) = $req.body {
+            query.body(body)
+        } else {
+            query.body("")
+        };
+
+        query.build().unwrap()
+    }}
+}
+
+#[derive(Default)]
+pub struct ReqwestHurl;
+
+impl ReqwestHurl {
+    pub fn new() -> ReqwestHurl {
+        ReqwestHurl::default()
+    }
+}
+
+impl Hurl for ReqwestHurl {
+    fn request(&self, req: Request) -> HurlResult {
+        let client = Client::new();
+
+        let request = craft_request!(client, req);
+
+        Box::new(match client.execute(request) {
+            Ok(mut resp) => {
+                let status = resp.status().as_u16();
+                let body = match resp.text() {
+                    Ok(s) => s,
+                    Err(_) => "".to_string()
+                };
+                fok(Response { status, body })
+            },
+            Err(e) => ferr(format!("{:?}", e))
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct ReqwestAsyncHurl;
+
+impl ReqwestAsyncHurl {
+    pub fn new() -> ReqwestAsyncHurl {
+        ReqwestAsyncHurl::default()
+    }
+}
+
+impl Hurl for ReqwestAsyncHurl {
+    fn request(&self, req: Request) -> HurlResult {
+        let client = ClientAsync::new();
+        let request = craft_request!(client, req);
+
+        Box::new(client
+            .execute(request)
+            .and_then(|resp| {
+                let status = resp.status().as_u16();
+
+                resp.into_body().concat2().and_then(move |body| {
+                    Ok(String::from_utf8(body.to_vec()).unwrap())
+                }).and_then(move |body|
+                    Ok(Response {
+                        status,
+                        body
+                    })
+                )
+            })
+            .map_err(|e| format!("{:?}", e))
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod measurement;
 
 use client::Credentials;
 use client::http::HttpClient;
-use hurl::hyper::HyperHurl;
+use hurl::{hyper::HyperHurl, reqwest::{ReqwestHurl, ReqwestAsyncHurl}};
 use serializer::line::LineSerializer;
 
 /// Simple factory of `HttpClient` with `LineSerializer`
@@ -35,7 +35,9 @@ use serializer::line::LineSerializer;
 /// let client = create_client(credentials, vec!["http://localhost:8086"]);
 /// ```
 pub fn create_client<'a>(credentials: Credentials<'a>, hosts: Vec<&'a str>) -> HttpClient<'a> {
-    let mut client = HttpClient::new(credentials, Box::new(LineSerializer::new()), Box::new(HyperHurl::new()));
+    let mut client = HttpClient::new(credentials,
+                                     Box::new(LineSerializer::new()),
+                                     Box::new(HyperHurl::new()));
 
     for host in hosts {
         client.add_host(host);
@@ -44,3 +46,28 @@ pub fn create_client<'a>(credentials: Credentials<'a>, hosts: Vec<&'a str>) -> H
     client
 }
 
+pub fn create_reqwest_client<'a>(credentials: Credentials<'a>,
+                                 hosts: Vec<&'a str>) -> HttpClient<'a> {
+    let mut client = HttpClient::new(credentials,
+                                     Box::new(LineSerializer::new()),
+                                     Box::new(ReqwestHurl::new()));
+
+    for host in hosts {
+        client.add_host(host);
+    }
+
+    client
+}
+
+pub fn create_async_reqwest_client<'a>(credentials: Credentials<'a>,
+                                       hosts: Vec<&'a str>) -> HttpClient<'a> {
+    let mut client = HttpClient::new(credentials,
+                                     Box::new(LineSerializer::new()),
+                                     Box::new(ReqwestAsyncHurl::new()));
+
+    for host in hosts {
+        client.add_host(host);
+    }
+
+    client
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-extern crate tokio;
-extern crate tokio_executor;
 extern crate futures;
 extern crate http;
 extern crate base64;
 extern crate hyper;
+extern crate reqwest;
 extern crate url;
 
 pub mod client;


### PR DESCRIPTION
Hyper does not comes with HTTPS support out-of-the-box anymore. This PR adds two more Hurl implementation using the Reqwest crate: a regular synchronous one and an async one.