### PR TITLE
Replace `&'a str` with `String`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,7 @@
-use ::measurement::Measurement;
-use std::io;
-use futures::Future;
 
+use futures::Future;
+use measurement::Measurement;
+use std::io;
 pub mod http;
 
 pub trait Client {
@@ -10,10 +10,10 @@ pub trait Client {
     fn query(&self, String, Option<Precision>) -> ClientReadResult;
 }
 
-pub struct Credentials<'a> {
-    pub username: &'a str,
-    pub password: &'a str,
-    pub database: &'a str
+pub struct Credentials {
+    pub username: String,
+    pub password: String,
+    pub database: String,
 }
 
 pub enum Precision {
@@ -22,28 +22,28 @@ pub enum Precision {
     Milliseconds,
     Seconds,
     Minutes,
-    Hours
+    Hours,
 }
 
 impl ToString for Precision {
     fn to_string(&self) -> String {
         let s = match *self {
-            Precision::Nanoseconds  => "n",
+            Precision::Nanoseconds => "n",
             Precision::Microseconds => "u",
             Precision::Milliseconds => "ms",
-            Precision::Seconds      => "s",
-            Precision::Minutes      => "m",
-            Precision::Hours        => "h"
+            Precision::Seconds => "s",
+            Precision::Minutes => "m",
+            Precision::Hours => "h",
         };
 
         s.to_string()
     }
 }
 
-pub type ClientWriteResult = Box<Future<Item=(), Error=ClientError> + Send>;
+pub type ClientWriteResult = Box<Future<Item = (), Error = ClientError> + Send>;
 
 // TODO: here parsing json?
-pub type ClientReadResult = Box<Future<Item=String, Error=ClientError> + Send>;
+pub type ClientReadResult = Box<Future<Item = String, Error = ClientError> + Send>;
 
 #[derive(Debug)]
 pub enum ClientError {
@@ -51,7 +51,7 @@ pub enum ClientError {
     Communication(String),
     Syntax(String),
     Unexpected(String),
-    Unknown
+    Unknown,
 }
 
 impl From<io::Error> for ClientError {

--- a/src/hurl/hyper.rs
+++ b/src/hurl/hyper.rs
@@ -29,7 +29,7 @@ impl Hurl for HyperHurl {
             Method::GET  => HyperMethod::GET,
         };
 
-        let mut url = match Url::parse(req.url) {
+        let mut url = match Url::parse(&req.url) {
             Ok(u) => { u }
             Err(e) => {
                 return Box::new(futures::future::err(format!("could not parse url: {:?}", e)));

--- a/src/hurl/mod.rs
+++ b/src/hurl/mod.rs
@@ -8,11 +8,11 @@ pub trait Hurl {
 }
 
 #[derive(Debug)]
-pub struct Request<'a> {
-    pub url: &'a str,
+pub struct Request {
+    pub url: String,
     pub method: Method,
-    pub auth: Option<Auth<'a>>,
-    pub query: Option<HashMap<&'a str, String>>,
+    pub auth: Option<Auth>,
+    pub query: Option<HashMap<String, String>>,
     pub body: Option<String>
 }
 
@@ -37,7 +37,7 @@ pub enum Method {
 }
 
 #[derive(Debug)]
-pub struct Auth<'a> {
-    pub username: &'a str,
-    pub password: &'a str
+pub struct Auth {
+    pub username: String,
+    pub password: String
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,14 @@ use serializer::line::LineSerializer;
 /// use influent::client::Credentials;
 ///
 /// let credentials = Credentials {
-///     username: "gobwas",
-///     password: "xxx",
-///     database: "mydb"
+///     username: String::from("gobwas"),
+///     password: String::from("xxx"),
+///     database: String::from("mydb")
 /// };
 ///
-/// let client = create_client(credentials, vec!["http://localhost:8086"]);
+/// let client = create_client(credentials, vec![String::from("http://localhost:8086")]);
 /// ```
-pub fn create_client<'a>(credentials: Credentials<'a>, hosts: Vec<&'a str>) -> HttpClient<'a> {
+pub fn create_client(credentials: Credentials, hosts: Vec<String>) -> HttpClient {
     let mut client = HttpClient::new(credentials, Box::new(LineSerializer::new()), Box::new(HyperHurl::new()));
 
     for host in hosts {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,29 +7,36 @@ use influent::client::{Client, Credentials};
 use influent::client::http::HttpClient;
 use influent::measurement::{Measurement, Value};
 use futures::Future;
+
 use std::sync::Arc;
 
-fn before<'a>() -> HttpClient<'a> {
-	let credentials = Credentials {
-        username: "gobwas",
-        password: "xxxx",
-        database: "test"
+fn before() -> HttpClient {
+    let credentials = Credentials {
+        username: String::from("gobwas"),
+        password: String::from("xxxx"),
+        database: String::from("test"),
     };
 
-    let client = Arc::new(create_client(credentials, vec!["http://localhost:8086"]));
+    let client = Arc::new(create_client(
+        credentials,
+        vec![String::from("http://localhost:8086")],
+    ));
 
     {
         let client = client.clone();
         let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
         rt.block_on(
-            client.query("drop database test".to_string(), None).then(move |_| {
-                client.query("create database test".to_string(), None)
-            }).map(|_| ()).map_err(|_| ())
-        ).unwrap();
+            client
+                .query("drop database test".to_string(), None)
+                .then(move |_| client.query("create database test".to_string(), None))
+                .map(|_| ())
+                .map_err(|_| ()),
+        )
+        .unwrap();
     }
 
     if let Ok(client) = Arc::try_unwrap(client) {
-        return client
+        return client;
     }
     panic!("wtf")
 }
@@ -56,7 +63,7 @@ fn test_write_measurement() {
     rt.block_on(client.write_one(measurement, None).then(move |_| {
         client.query("select * from \"sut\"".to_string(), None)
     }).map(|res| {
-        let fixture = "{\"results\":[{\"series\":[{\"name\":\"sut\",\"columns\":[\"time\",\"boolean\",\"float\",\"integer\",\"string\",\"tag\",\"tag, with comma\",\"with, comma\"],\"values\":[[\"2015-06-11T20:46:02Z\",false,10,10,\"string\",\"value\",\"three, four\",\"comma, with\"]]}]}]}";
+        let fixture = "{\"results\":[{\"statement_id\":0,\"series\":[{\"name\":\"sut\",\"columns\":[\"time\",\"boolean\",\"float\",\"integer\",\"string\",\"tag\",\"tag, with comma\",\"with, comma\"],\"values\":[[\"2015-06-11T20:46:02Z\",false,10,10,\"string\",\"value\",\"three, four\",\"comma, with\"]]}]}]}\n";
         assert_eq!(fixture, res);
     }).map_err(|e| println!("{:?}", e))).unwrap();
 }


### PR DESCRIPTION
Using `&'a str` for credentials in the library is quite cumbersome, as it's impossible, if not very hacky to inline credentials at runtime.

Without this fix, something like

```
let credentials = Credentials {
    username: env::option_env!("DB_USERNAME").unwrap_or("gobwas"),
    password: env::option_env!("DB_PASSWORD").unwrap_or("hunter2"),
    database: "influentrs",
};
let host = format!("http://{}:8086", env::option_env!("DB_HOST").unwrap_or("localhost"));
let client = create_client(credentials, vec![host]);
```

is impossible, as the `format!()` macro or `std::option_env!()` and most other methods return String instead of `&'a str`. This also fixes the need to `Box` the client if it needs to be returned from a method.